### PR TITLE
Add PayPal Account Updater webhook implementation

### DIFF
--- a/backend/app/events/anthropic_api.py
+++ b/backend/app/events/anthropic_api.py
@@ -1,0 +1,121 @@
+import logging
+import requests
+import json
+from typing import Dict, Any, Optional
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("anthropic_api")
+
+# Database API endpoint (adjust this to match your actual database API)
+DB_API_ENDPOINT = "http://localhost:8000/api"
+
+def update_card_by_subscription_id(subscription_id: str, attributes: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Update card attributes in the database using the subscription_id as identifier.
+    
+    Args:
+        subscription_id: The PayPal subscription ID for the card
+        attributes: Dictionary of attributes to update
+        
+    Returns:
+        Dict: Response from the database API
+    """
+    try:
+        logger.info(f"Updating card with subscription_id {subscription_id}")
+        logger.info(f"Attributes to update: {attributes}")
+        
+        # Make API call to your database service
+        response = requests.put(
+            f"{DB_API_ENDPOINT}/cards/subscription/{subscription_id}",
+            json=attributes
+        )
+        
+        # Check if request was successful
+        if response.status_code == 200:
+            result = response.json()
+            logger.info(f"Card updated successfully: {result}")
+            return {"success": True, "data": result}
+        else:
+            logger.error(f"Failed to update card: {response.status_code} - {response.text}")
+            return {"success": False, "error": f"API error: {response.status_code}"}
+    
+    except requests.RequestException as e:
+        logger.error(f"Request error: {str(e)}")
+        return {"success": False, "error": f"Request error: {str(e)}"}
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        return {"success": False, "error": f"Unexpected error: {str(e)}"}
+
+def get_card_by_subscription_id(subscription_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Retrieve card information from the database using subscription_id.
+    
+    Args:
+        subscription_id: The PayPal subscription ID for the card
+        
+    Returns:
+        Optional[Dict]: Card information if found, None otherwise
+    """
+    try:
+        logger.info(f"Getting card with subscription_id {subscription_id}")
+        
+        # Make API call to your database service
+        response = requests.get(
+            f"{DB_API_ENDPOINT}/cards/subscription/{subscription_id}"
+        )
+        
+        # Check if request was successful
+        if response.status_code == 200:
+            result = response.json()
+            logger.info(f"Card retrieved successfully")
+            return result
+        elif response.status_code == 404:
+            logger.warning(f"Card with subscription_id {subscription_id} not found")
+            return None
+        else:
+            logger.error(f"Failed to retrieve card: {response.status_code} - {response.text}")
+            return None
+    
+    except requests.RequestException as e:
+        logger.error(f"Request error: {str(e)}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        return None
+
+def create_subscription_record(card_id: int, subscription_id: str) -> Dict[str, Any]:
+    """
+    Create a record of a new PayPal account updater subscription.
+    
+    Args:
+        card_id: The internal database ID for the card
+        subscription_id: The PayPal subscription ID
+        
+    Returns:
+        Dict: Response from the database API
+    """
+    try:
+        logger.info(f"Creating subscription record for card_id {card_id}")
+        
+        # Make API call to your database service
+        response = requests.post(
+            f"{DB_API_ENDPOINT}/cards/{card_id}/subscription",
+            json={"subscription_id": subscription_id}
+        )
+        
+        # Check if request was successful
+        if response.status_code == 201:
+            result = response.json()
+            logger.info(f"Subscription record created successfully: {result}")
+            return {"success": True, "data": result}
+        else:
+            logger.error(f"Failed to create subscription record: {response.status_code} - {response.text}")
+            return {"success": False, "error": f"API error: {response.status_code}"}
+    
+    except requests.RequestException as e:
+        logger.error(f"Request error: {str(e)}")
+        return {"success": False, "error": f"Request error: {str(e)}"}
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        return {"success": False, "error": f"Unexpected error: {str(e)}"}

--- a/backend/app/events/webhook_card_update.py
+++ b/backend/app/events/webhook_card_update.py
@@ -1,0 +1,176 @@
+from fastapi import APIRouter, Request, HTTPException, Depends
+from fastapi.responses import JSONResponse
+import json
+import logging
+import hmac
+import hashlib
+import base64
+import os
+from typing import Dict, Any
+from datetime import datetime
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("webhook_card_update")
+
+# Create router
+router = APIRouter()
+
+# PayPal webhook secret - In production, store this in environment variables
+WEBHOOK_SECRET = os.getenv("PAYPAL_WEBHOOK_SECRET", "your-webhook-secret")
+
+async def verify_webhook_signature(request: Request) -> bool:
+    """
+    Verify that the webhook request is coming from PayPal by validating the signature.
+    
+    Args:
+        request: The incoming webhook request
+        
+    Returns:
+        bool: True if signature is valid, False otherwise
+    """
+    try:
+        # Get PayPal signature from header
+        paypal_signature = request.headers.get("PAYPAL-TRANSMISSION-SIG")
+        paypal_cert_url = request.headers.get("PAYPAL-CERT-URL")
+        paypal_transmission_id = request.headers.get("PAYPAL-TRANSMISSION-ID")
+        paypal_transmission_time = request.headers.get("PAYPAL-TRANSMISSION-TIME")
+        
+        if not all([paypal_signature, paypal_cert_url, paypal_transmission_id, paypal_transmission_time]):
+            logger.error("Missing required PayPal signature headers")
+            return False
+        
+        # Get request body
+        body = await request.body()
+        
+        # Create the validation string
+        validation_string = f"{paypal_transmission_id}|{paypal_transmission_time}|{body.decode('utf-8')}"
+        
+        # Generate signature using HMAC with SHA256
+        hmac_obj = hmac.new(
+            WEBHOOK_SECRET.encode('utf-8'),
+            validation_string.encode('utf-8'),
+            hashlib.sha256
+        )
+        
+        signature = base64.b64encode(hmac_obj.digest()).decode('utf-8')
+        
+        # Compare signatures
+        return hmac.compare_digest(signature, paypal_signature)
+    except Exception as e:
+        logger.error(f"Signature verification error: {str(e)}")
+        return False
+
+async def update_card_in_database(event_data: Dict[str, Any]) -> bool:
+    """
+    Update card information in database based on webhook event.
+    
+    Args:
+        event_data: The webhook event data containing updated card information
+        
+    Returns:
+        bool: True if database update is successful, False otherwise
+    """
+    try:
+        # Extract necessary information from event
+        resource = event_data.get("resource", {})
+        subscription_id = resource.get("id")
+        
+        if not subscription_id:
+            logger.error("Missing subscription ID in event data")
+            return False
+        
+        # Get updated card details
+        updated_card_data = resource.get("account_status", {})
+        if not updated_card_data:
+            logger.error("No card update information found in event")
+            return False
+        
+        # Extract updated card details
+        new_expiry_date = updated_card_data.get("expiry")
+        new_card_status = updated_card_data.get("status")
+        
+        # Format expiry date if needed (PayPal format: YYYY-MM to MM/YYYY)
+        if new_expiry_date:
+            try:
+                year, month = new_expiry_date.split("-")
+                formatted_expiry = f"{month}/{year}"
+            except ValueError:
+                formatted_expiry = new_expiry_date
+        else:
+            formatted_expiry = None
+        
+        # Prepare attributes to update
+        attributes = {}
+        if formatted_expiry:
+            attributes["expiry_date"] = formatted_expiry
+        if new_card_status:
+            attributes["status"] = new_card_status
+        
+        if not attributes:
+            logger.info("No attributes to update")
+            return True
+        
+        # Update card in database
+        from anthropic_api import update_card_by_subscription_id
+        result = update_card_by_subscription_id(subscription_id, attributes)
+        
+        logger.info(f"Card update result: {result}")
+        return True
+    except Exception as e:
+        logger.error(f"Database update error: {str(e)}")
+        return False
+
+@router.post("/paypal/card-updated")
+async def webhook_card_updated(request: Request):
+    """
+    Handle PayPal Account Updater webhook events for card updates.
+    
+    Args:
+        request: The incoming webhook request
+        
+    Returns:
+        JSONResponse: Confirmation of webhook processing
+    """
+    try:
+        # Verify webhook signature
+        is_valid = await verify_webhook_signature(request)
+        if not is_valid:
+            logger.warning("Invalid webhook signature")
+            raise HTTPException(status_code=401, detail="Invalid signature")
+        
+        # Parse webhook payload
+        body = await request.body()
+        event_data = json.loads(body)
+        
+        # Log webhook event
+        event_type = event_data.get("event_type", "unknown")
+        logger.info(f"Received PayPal webhook: {event_type}")
+        
+        # Process different event types
+        if event_type == "ACCOUNT.STATUS.UPDATED":
+            # Handle card update event
+            success = await update_card_in_database(event_data)
+            if not success:
+                logger.error("Failed to update card in database")
+                return JSONResponse(
+                    status_code=500,
+                    content={"status": "error", "message": "Failed to process card update"}
+                )
+            
+            return JSONResponse(
+                content={"status": "success", "message": "Card updated successfully"}
+            )
+        else:
+            # Log unhandled event type
+            logger.info(f"Unhandled event type: {event_type}")
+            return JSONResponse(
+                content={"status": "success", "message": "Event acknowledged but not processed"}
+            )
+    
+    except json.JSONDecodeError:
+        logger.error("Invalid JSON payload")
+        raise HTTPException(status_code=400, detail="Invalid JSON payload")
+    except Exception as e:
+        logger.error(f"Webhook processing error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error processing webhook: {str(e)}")


### PR DESCRIPTION
This PR adds PayPal Account Updater webhook implementation to automatically update card information when changes are detected.

## Features:
- Added webhook endpoint to receive PayPal card update events
- Implemented signature verification for secure webhook processing
- Added API helper functions to update card information in the database
- Handles card expiry date updates and status changes

## Testing:
- Webhook can be tested locally with the following curl command:
```bash
curl -X POST "http://localhost:8000/api/paypal/card-updated" \
     -H "Content-Type: application/json" \
     -H "PAYPAL-TRANSMISSION-SIG: [signature]" \
     -H "PAYPAL-CERT-URL: [cert_url]" \
     -H "PAYPAL-TRANSMISSION-ID: [transmission_id]" \
     -H "PAYPAL-TRANSMISSION-TIME: [transmission_time]" \
     -d '{"event_type":"ACCOUNT.STATUS.UPDATED","resource":{"id":"SUB-12345","account_status":{"expiry":"2030-12","status":"ACTIVE"}}}'
```

## Configuration:
- Set the `PAYPAL_WEBHOOK_SECRET` environment variable for secure signature verification in production